### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Hugo Site to GitHub Pages
+﻿name: Deploy Hugo Site to GitHub Pages
 
 on:
   push:
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -41,5 +41,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           force_orphan: true
-          clean: true
           cname: www.carlvinjerry.com
+

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: PR Workflows
+﻿name: PR Workflows
 
 on:
   pull_request:
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -30,10 +30,10 @@ jobs:
     needs: blog-post-checks
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -49,3 +49,4 @@ jobs:
 
       - name: Build
         run: hugo --gc --minify --enableGitInfo
+

--- a/.github/workflows/theme-update.yml
+++ b/.github/workflows/theme-update.yml
@@ -1,4 +1,4 @@
-name: "Theme Update"
+﻿name: "Theme Update"
 
 on:
   schedule:
@@ -8,12 +8,12 @@ jobs:
   update-theme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v7
         with:
           ref: develop
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -50,3 +50,4 @@ jobs:
           base: develop
           title: Update theme
           labels: theme-update
+


### PR DESCRIPTION
## Summary
- update checkout/setup-node actions to v7 so workflows no longer run Node-20-based actions
- remove obsolete clean input from peaceiris/actions-gh-pages@v4

## Verification
- workflow YAML parse check
- npm run check:blog
- hugo --gc --minify --enableGitInfo