### PR TITLE
Promote blog pushes from develop

### DIFF
--- a/.github/workflows/promote-blog.yml
+++ b/.github/workflows/promote-blog.yml
@@ -1,0 +1,86 @@
+name: Promote Blog Changes
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+
+concurrency:
+  group: promote-blog
+  cancel-in-progress: false
+
+jobs:
+  check-and-promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check blog posts
+        run: npm run check:blog
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: latest
+          extended: true
+
+      - name: Build
+        run: hugo --gc --minify --enableGitInfo
+
+      - name: Promote blog-only changes to main
+        id: promote
+        run: |
+          set -euo pipefail
+
+          git fetch origin main develop
+
+          changed_files="$(git diff --name-only origin/main..origin/develop)"
+          if [ -z "$changed_files" ]; then
+            echo "No changes to promote."
+            echo "promoted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          disallowed_files="$(printf '%s\n' "$changed_files" \
+            | grep -Ev '^(content/posts/|assets/images/|static/images/|static/files/)' || true)"
+
+          if [ -n "$disallowed_files" ]; then
+            echo "Develop contains non-blog changes, so main will not be updated automatically:"
+            echo "$disallowed_files"
+            echo "promoted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git switch main
+          git reset --hard origin/main
+          git merge --ff-only origin/develop
+          git push origin main
+          echo "promoted=true" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy promoted site
+        if: steps.promote.outputs.promoted == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          force_orphan: true
+          cname: www.carlvinjerry.com

--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Static Hugo site for [www.carlvinjerry.com](https://www.carlvinjerry.com/), host
 
 ## Adding A Blog Post
 
-Create a branch from `develop`:
+For ordinary blog posts, work directly on `develop`:
 
 ```powershell
 git switch develop
 git pull --ff-only origin develop
-git switch -c post/my-new-post
 ```
 
 Add the post under `content/posts/...`. Article files should usually be named `index.md` or `index.markdown` inside a folder for that post.
@@ -55,18 +54,19 @@ npm run check:blog
 hugo --gc --minify --enableGitInfo
 ```
 
-Push and open a PR into `develop`:
+Commit and push to `develop`:
 
 ```powershell
 git add content/posts
 git commit -m "Add my new post"
-git push -u origin post/my-new-post
-gh pr create --base develop --head post/my-new-post --title "Add my new post"
+git push origin develop
 ```
+
+After the push, GitHub Actions runs `Promote Blog Changes`. If the full diff from `main` to `develop` only contains blog/content asset files and checks pass, it updates `main` automatically. The `main` deployment workflow then publishes the site.
 
 ## Blog Automerge
 
-Blog PRs can be merged automatically into `develop` when all of these are true:
+Direct pushes to `develop` are the normal path for blog posts. Blog PRs are still supported when you want review first, and can be merged automatically into `develop` when all of these are true:
 
 - the PR targets `develop`
 - the PR has the `automerge-blog` label
@@ -74,6 +74,13 @@ Blog PRs can be merged automatically into `develop` when all of these are true:
 - changed files are limited to `content/posts/`, `assets/images/`, `static/images/`, or `static/files/`
 
 Do not use `automerge-blog` for theme, workflow, dependency, or deployment changes.
+
+Direct-push promotion from `develop` to `main` is intentionally blog-only. If `develop` contains changes outside these paths, the promotion workflow skips the push to `main`:
+
+- `content/posts/`
+- `assets/images/`
+- `static/images/`
+- `static/files/`
 
 ## Theme Updates
 


### PR DESCRIPTION
## Summary
- add a push-to-develop workflow that validates blog posts and Hugo build
- automatically fast-forwards main when the full main..develop diff is blog/content asset-only
- deploys the promoted build because GITHUB_TOKEN pushes do not reliably trigger a second workflow
- update README so new blog posts can be committed directly to develop

## Safety guard
Promotion skips automatically when develop contains files outside:
- content/posts/
- assets/images/
- static/images/
- static/files/

## Verification
- workflow YAML parse check
- npm run check:blog
- hugo --gc --minify --enableGitInfo