### PR TITLE
Require summaries in blog checks

### DIFF
--- a/content/posts/Quantitative-Finance/moving averages/index.md
+++ b/content/posts/Quantitative-Finance/moving averages/index.md
@@ -12,6 +12,7 @@ menu:
 hero: movingavgs.png
 tags: [Algorithmic Trading,Quantitative Finance,Time Series Analysis]
 description: "Learn how to build a Moving Average Crossover trading strategy in F#—a beginner-friendly guide to algorithmic trading. This step-by-step tutorial breaks down the math behind trend-following signals, implements a clean F# pipeline for backtesting, and explains key concepts like window sizing, thresholds, and risk management. Perfect for quant developers exploring functional programming or traders dipping their toes into systematic strategies. Includes ready-to-run code examples and practical extensions to adapt the strategy to real markets."
+summary: "This post builds a simple moving average crossover strategy in F#, explaining short and long windows, crossover signals, thresholds, and the structure of a testable trading pipeline."
 canonical: "https://blogs.innova.co.ke/moving-averages/"
 ---
 

--- a/content/posts/Quantitative-Finance/portfolio risk attribution/index.md
+++ b/content/posts/Quantitative-Finance/portfolio risk attribution/index.md
@@ -3,6 +3,7 @@ title: "Attributing for Risk in Portfolio Management"
 author: Carlvin Jerry
 date: 2024-12-02T21:37:25+06:00
 description: A Guide to Calculating Risk Contributions in Portfolio Management Using Volatility
+summary: "This post explains portfolio risk attribution, showing how volatility and risk contribution formulas help identify which assets drive overall portfolio risk."
 canonical: "https://blogs.innova.co.ke/portfolio-risk-attribution.md/"
 hero: risk.jpg
 image: /images/risk.jpg

--- a/content/posts/introduction/index.md
+++ b/content/posts/introduction/index.md
@@ -2,6 +2,7 @@
 title: "Introduction"
 date: 2020-06-08T08:06:25+06:00
 description: Introduction to Sample Post
+summary: "A short starter post that validates the site's post layout, sidebar placement, author metadata, multilingual setup, and local hero image behavior."
 menu:
   sidebar:
     name: Introduction

--- a/content/posts/programming/Code-Sustainability/Error Handling/python exceptions/index.md
+++ b/content/posts/programming/Code-Sustainability/Error Handling/python exceptions/index.md
@@ -2,6 +2,7 @@
 
 title: "Mastering Python's Exceptional Complexity"
 description: "Mastering Python's Exceptional Complexity for Sustainable Error Handling"
+summary: "This post explains Python exception handling from syntax errors through try, except, else, and finally blocks, showing how structured error handling improves resilience, cleanup, and code clarity."
 date: 2023-09-14T06:00:20+06:00
 image: errors.jpg
 hero: errors.jpg

--- a/content/posts/programming/Code-Sustainability/Succint FSharp/currying/index.md
+++ b/content/posts/programming/Code-Sustainability/Succint FSharp/currying/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Currying and Partial Application in F#"
 description: A deep dive into currying and partial application in F# with examples and use cases in functional programming.
+summary: "This post breaks down currying and partial application in F#, explaining how multi-argument functions can be composed, reused, and specialized for cleaner functional programming workflows."
 date: 2024-10-07T08:06:25+06:00
 canonical: https://www.innova.co.ke/currying-and-partial-application/
 hero: partial.jpg 

--- a/content/posts/programming/Code-Sustainability/Succint FSharp/fs option type/index.md
+++ b/content/posts/programming/Code-Sustainability/Succint FSharp/fs option type/index.md
@@ -3,6 +3,7 @@
 title: "Enhancing Code Maintainability with the F# 'Option' Type"
 date: 2024-09-17T08:06:25+06:00
 description: "A practical look at F# option types for safer, more maintainable code."
+summary: "This post introduces the F# Option type as a safer alternative to nulls, using pattern matching and higher-order helpers to make missing values explicit and maintainable."
 image: /images/maintenance.jpg
 hero: maintenance.jpg
 menu:

--- a/content/posts/programming/Code-Sustainability/Succint FSharp/memoization/index.md
+++ b/content/posts/programming/Code-Sustainability/Succint FSharp/memoization/index.md
@@ -3,6 +3,7 @@ title: "Memoization with Fibonacci"
 author: Carlvin Jerry
 date: 2024-11-04T21:37:25+06:00
 description: A Guide to Optimized Functional Programming with Memoization in F#
+summary: "This post explains memoization as a functional performance optimization technique, using repeated computations to show how caching improves F# code efficiency."
 canonical: "https://blogs.innova.co.ke/memoization/"
 image: /images/memory.jpg
 menu:

--- a/content/posts/programming/Code-Sustainability/Succint FSharp/pattern matching/index.md
+++ b/content/posts/programming/Code-Sustainability/Succint FSharp/pattern matching/index.md
@@ -3,6 +3,7 @@ title: " Optimizing Pattern Matching in F# for Better Performance "
 author: Carlvin Jerry
 date: 2025-03-03T21:37:25+06:00
 description: A Guide to Optimized Functional Programming with improved pattern matching.
+summary: "This post explores pattern matching in F# and shows how to structure match expressions for clearer, more efficient functional code when working with larger data shapes."
 image: /images/patterns.jpg
 menu:
   sidebar:

--- a/content/posts/programming/Code-Sustainability/Succint FSharp/working-with-paket/index.md
+++ b/content/posts/programming/Code-Sustainability/Succint FSharp/working-with-paket/index.md
@@ -2,6 +2,7 @@
 title: "A Better Way to Manage Dependencies in F#"
 date: 2024-10-22T21:37:25+06:00
 description: Using Paket as an Alternative to NuGet for Dependency Management in F#
+summary: "This post introduces Paket as an alternative dependency manager for F# and .NET projects, focusing on clearer dependency resolution and maintainable project setup."
 canonical: https://carlvinjerry.com/posts/code-sustainability/succint-fsharp/working-with-paket/
 hero: packages.jpg
 image: /images/packages.jpg

--- a/content/posts/programming/Functional Programming/functional-programming/index.md
+++ b/content/posts/programming/Functional Programming/functional-programming/index.md
@@ -2,6 +2,7 @@
 title: "Functional Programming"
 date: 2023-04-20T19:17:21+03:00
 description: "A deep dive into the world of functional programming and its practical implications"
+summary: "This post introduces functional programming principles such as pure functions, immutability, first-class functions, and higher-order composition, with practical F# examples."
 readingTime: true
 image: /images/functional.jpg
 categories: ["Programming", "Languages", "F#"]

--- a/content/posts/programming/languages/fsharp/fsharp-9-review/index.md
+++ b/content/posts/programming/languages/fsharp/fsharp-9-review/index.md
@@ -2,6 +2,7 @@
 title: "What’s New in F# 9 for Quant Developers"
 date: 2025-04-23T19:51:10+03:00
 description: "F# 9 introduces powerful language features—such as improved type inference, enhanced pattern matching, anonymous record updates, and custom equality for structs—that streamline quantitative workflows and reduce code complexity in financial modeling and data processing."
+summary: "This post reviews F# 9 features through a quant-developer lens, covering language improvements that make financial modeling, data workflows, and high-integrity code easier to express."
 readingTime: true
 image: /images/fsharp.png
 categories: ["Programming", "Languages", "F#"]

--- a/scripts/check-blog-posts.mjs
+++ b/scripts/check-blog-posts.mjs
@@ -117,6 +117,7 @@ for (const filePath of walk(postsRoot)) {
   if (isArticle(filePath)) {
     assertDate(data.date, filePath);
     assertText(data.description, "description", filePath);
+    assertText(data.summary, "summary", filePath);
   }
 }
 


### PR DESCRIPTION
## Summary
- make npm run check:blog require summary for article posts
- backfill summaries on older articles so post cards stay uniform
- keep section _index pages exempt from article summary requirements

## Verification
- npm run check:blog
- hugo --gc --minify --enableGitInfo